### PR TITLE
add prometheus and InfluxDB V2 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ ENV BRANCH_RTLSDR="ed0317e6a58c098874ac58b769cf2e609c18d9a5" \
     URL_REPO_RTLSDR="git://git.osmocom.org/rtl-sdr" \
     URL_REPO_SOAPYRTLSDR="https://github.com/pothosware/SoapyRTLSDR.git" \
     URL_REPO_SOAPYSDR="https://github.com/pothosware/SoapySDR.git" \
-    URL_REPO_UAT2ESNT="https://github.com/adsbxchange/uat2esnt.git"
+    URL_REPO_UAT2ESNT="https://github.com/adsbxchange/uat2esnt.git" \
+    ###########################################################################
+    PROMETHEUSPORT=9273 \
+    PROMETHEUSPATH="/metrics"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,15 @@ These variables control the sending of flight data and dump978 metrics to [Influ
 | `INFLUXDBUSERNAME` | If using authentication, a username for your InfluxDB instance. If not using authentication, leave unset. | Unset |
 | `INFLUXDBPASSWORD` | If using authentication, a password for your InfluxDB instance. If not using authentication, leave unset. | Unset |
 
-If `INFLUXDBURL` is left unset, the built-in instance of Telegraf will not be started.
+### Prometheus Options
+
+These variables control exposing flight data and readsb metrics to [Prometheus](https://prometheus.io) (via a built-in instance of [Telegraf](https://docs.influxdata.com/telegraf/)).
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ENABLE_PROMETHEUS` | Set to any string to enable Prometheus support | Unset |
+| `PROMETHEUSPORT` | The port that the prometheus client will listen on | `9273` |
+| `PROMETHEUSPATH` | The path that the prometheus client will publish metrics on | `/metrics` |
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -180,9 +180,13 @@ These variables control the sending of flight data and dump978 metrics to [Influ
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `INFLUXDBURL` | The full HTTP URL for your InfluxDB instance. | Unset |
-| `INFLUXDBUSERNAME` | If using authentication, a username for your InfluxDB instance. If not using authentication, leave unset. | Unset |
-| `INFLUXDBPASSWORD` | If using authentication, a password for your InfluxDB instance. If not using authentication, leave unset. | Unset |
+| `INFLUXDBURL` | The full HTTP URL for your InfluxDB instance. Required for both InfluxDB v1 and v2. | Unset |
+| `INFLUXDBUSERNAME` | If using authentication, a username for your InfluxDB instance. If not using authentication, leave unset. Not required for InfluxDB v2. | Unset |
+| `INFLUXDBPASSWORD` | If using authentication, a password for your InfluxDB instance. If not using authentication, leave unset. Not required for InfluxDB v2. | Unset |
+| `INFLUXDB_V2` | Set to a non empty value to enable InfluxDB V2 output. | Unset |
+| `INFLUXDB_V2_BUCKET` | Required if `INFLUXDB_V2` is set, bucket must already exist in your InfluxDB v2 instance. | Unset |
+| `INFLUXDB_V2_ORG` | Required if `INFLUXDB_V2` is set. | Unset |
+| `INFLUXDB_V2_TOKEN` | Required if `INFLUXDB_V2` is set. | Unset |
 
 ### Prometheus Options
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ These variables control the sending of flight data and dump978 metrics to [Influ
 
 ### Prometheus Options
 
-These variables control exposing flight data and readsb metrics to [Prometheus](https://prometheus.io) (via a built-in instance of [Telegraf](https://docs.influxdata.com/telegraf/)).
+These variables control exposing flight data to [Prometheus](https://prometheus.io) (via a built-in instance of [Telegraf](https://docs.influxdata.com/telegraf/)).
 
 | Variable | Description | Default |
 |----------|-------------|---------|

--- a/rootfs/etc/cont-init.d/04-telegraf
+++ b/rootfs/etc/cont-init.d/04-telegraf
@@ -1,14 +1,26 @@
 #!/usr/bin/with-contenv bash
 #shellcheck shell=bash
 
+# Initialise config files, and remove existing
+OUTPUT_INFLUXDB_CONFIG_FILE="/etc/telegraf/telegraf.d/outputs_influxdb.conf"
+rm "$OUTPUT_INFLUXDB_CONFIG_FILE" > /dev/null 2>&1 || true
+INPUT_JSON_CONFIG_FILE="/etc/telegraf/telegraf.d/inputs_socket_listener_dump978_json.conf"
+rm "$INPUT_JSON_CONFIG_FILE" > /dev/null 2>&1 || true
+OUTPUT_PROMETHEUS_CONFIG_FILE="/etc/telegraf/telegraf.d/outputs_prometheus.conf"
+rm "$OUTPUT_PROMETHEUS_CONFIG_FILE" > /dev/null 2>&1 || true
+
+if [[ -n "$ENABLE_PROMETHEUS" ]]; then
+
+  ##### TELEGRAF CONFIG - OUTPUT TO INFLUXDB #####
+  {
+    echo "[[outputs.prometheus_client]]"
+    echo "  listen = \":${PROMETHEUSPORT}\""
+    echo "  path = \"${PROMETHEUSPATH}\""
+  } > "$OUTPUT_PROMETHEUS_CONFIG_FILE"
+
+fi
+
 if [[ -n "$INFLUXDBURL" ]]; then
-
-
-  # Initialise config files, and remove existing
-  OUTPUT_INFLUXDB_CONFIG_FILE="/etc/telegraf/telegraf.d/outputs_influxdb.conf"
-  rm "$OUTPUT_INFLUXDB_CONFIG_FILE" > /dev/null 2>&1 || true
-  INPUT_JSON_CONFIG_FILE="/etc/telegraf/telegraf.d/inputs_socket_listener_dump978_json.conf"
-  rm "$INPUT_JSON_CONFIG_FILE" > /dev/null 2>&1 || true
 
   ##### TELEGRAF CONFIG - OUTPUT TO INFLUXDB #####
   {
@@ -34,102 +46,101 @@ if [[ -n "$INFLUXDBURL" ]]; then
 
   } > "$OUTPUT_INFLUXDB_CONFIG_FILE"
 
-
-  ##### TELEGRAF CONFIG - INPUT FROM dump978 JSON #####
-  # Build telegraf config - input from dump978 VRS JSON
-  {
-    echo "[[inputs.socket_listener]]"
-
-    # Run every fairly often as VRS JSON comes out fast
-    echo "interval = \"1s\""
-    
-    ## URL to listen on
-    echo "service_address = \"tcp://127.0.0.1:33979\""
-
-    ## Maximum number of concurrent connections.
-    ## Only applies to stream sockets (e.g. TCP).
-    ## 0 (default) is unlimited.
-    echo "max_connections = 2"
-
-    ## Read timeout.
-    ## Only applies to stream sockets (e.g. TCP).
-    ## 0 (default) is unlimited.
-    echo "read_timeout = \"0\""
-
-    ## Period between keep alive probes.
-    ## Only applies to TCP sockets.
-    ## 0 disables keep alive probes.
-    ## Defaults to the OS configuration.
-    echo "keep_alive_period = \"1m\""
-
-    ## Content encoding for message payloads, can be set to "gzip" to or
-    ## "identity" to apply no encoding.
-    echo "content_encoding = \"identity\""
-
-    ## Data format to consume.
-    ## Each data format has its own unique set of configuration options, read
-    ## more about them here:
-    ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
-    echo "data_format = \"json\""
-
-    echo "json_strict = true"
-
-    ## Tag keys is an array of keys that should be added as tags.
-    echo "tag_keys = ["
-    echo "  \"address_qualifier\","
-    echo "  \"address\","
-    echo "  \"airground_state\","
-    echo "  \"callsign\","
-    echo "  \"capability_codes_es_in\","
-    echo "  \"capability_codes_tcas_operational\","
-    echo "  \"capability_codes_uat_in\","
-    echo "  \"emergency\","
-    echo "  \"emitter_category\","
-    echo "  \"flightplan_id\","
-    echo "  \"nic_supplement\","
-    echo "  \"operational_modes_atc_services\","
-    echo "  \"operational_modes_ident_active\","
-    echo "  \"operational_modes_tcas_ra_active\","
-    echo "  \"sil_supplement\","
-    echo "  \"single_antenna\","
-    echo "  \"utc_coupled\","
-    echo "  \"vv_src\","
-    echo "]"
-
-    ## String fields is an array of keys that should be added as string fields.
-    echo "json_string_fields = ["
-    echo "  \"address_qualifier\","
-    echo "  \"address\","
-    echo "  \"airground_state\","
-    echo "  \"callsign\","
-    echo "  \"capability_codes_es_in\","
-    echo "  \"capability_codes_tcas_operational\","
-    echo "  \"capability_codes_uat_in\","
-    echo "  \"emergency\","
-    echo "  \"emitter_category\","
-    echo "  \"flightplan_id\","
-    echo "  \"nic_supplement\","
-    echo "  \"operational_modes_atc_services\","
-    echo "  \"operational_modes_ident_active\","
-    echo "  \"operational_modes_tcas_ra_active\","
-    echo "  \"sil_supplement\","
-    echo "  \"single_antenna\","
-    echo "  \"utc_coupled\","
-    echo "  \"vv_src\","
-    echo "]"
-
-    ## Name override
-    echo "name_override = \"aircraft\""
-
-    ## Time key is the key containing the time that should be used to create the
-    ## metric.
-    echo "json_time_key = \"metadata_received_at\""
-
-    ## Time format is the time layout that should be used to interprete the
-    ## json_time_key.  The time must be `unix`, `unix_ms` or a time in the
-    ## "reference time".
-    echo "json_time_format =\"unix\""
-
-  } > "$INPUT_JSON_CONFIG_FILE"
-
 fi
+
+##### TELEGRAF CONFIG - INPUT FROM dump978 JSON #####
+# Build telegraf config - input from dump978 VRS JSON
+{
+  echo "[[inputs.socket_listener]]"
+
+  # Run every fairly often as VRS JSON comes out fast
+  echo "interval = \"1s\""
+  
+  ## URL to listen on
+  echo "service_address = \"tcp://127.0.0.1:33979\""
+
+  ## Maximum number of concurrent connections.
+  ## Only applies to stream sockets (e.g. TCP).
+  ## 0 (default) is unlimited.
+  echo "max_connections = 2"
+
+  ## Read timeout.
+  ## Only applies to stream sockets (e.g. TCP).
+  ## 0 (default) is unlimited.
+  echo "read_timeout = \"0\""
+
+  ## Period between keep alive probes.
+  ## Only applies to TCP sockets.
+  ## 0 disables keep alive probes.
+  ## Defaults to the OS configuration.
+  echo "keep_alive_period = \"1m\""
+
+  ## Content encoding for message payloads, can be set to "gzip" to or
+  ## "identity" to apply no encoding.
+  echo "content_encoding = \"identity\""
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  echo "data_format = \"json\""
+
+  echo "json_strict = true"
+
+  ## Tag keys is an array of keys that should be added as tags.
+  echo "tag_keys = ["
+  echo "  \"address_qualifier\","
+  echo "  \"address\","
+  echo "  \"airground_state\","
+  echo "  \"callsign\","
+  echo "  \"capability_codes_es_in\","
+  echo "  \"capability_codes_tcas_operational\","
+  echo "  \"capability_codes_uat_in\","
+  echo "  \"emergency\","
+  echo "  \"emitter_category\","
+  echo "  \"flightplan_id\","
+  echo "  \"nic_supplement\","
+  echo "  \"operational_modes_atc_services\","
+  echo "  \"operational_modes_ident_active\","
+  echo "  \"operational_modes_tcas_ra_active\","
+  echo "  \"sil_supplement\","
+  echo "  \"single_antenna\","
+  echo "  \"utc_coupled\","
+  echo "  \"vv_src\","
+  echo "]"
+
+  ## String fields is an array of keys that should be added as string fields.
+  echo "json_string_fields = ["
+  echo "  \"address_qualifier\","
+  echo "  \"address\","
+  echo "  \"airground_state\","
+  echo "  \"callsign\","
+  echo "  \"capability_codes_es_in\","
+  echo "  \"capability_codes_tcas_operational\","
+  echo "  \"capability_codes_uat_in\","
+  echo "  \"emergency\","
+  echo "  \"emitter_category\","
+  echo "  \"flightplan_id\","
+  echo "  \"nic_supplement\","
+  echo "  \"operational_modes_atc_services\","
+  echo "  \"operational_modes_ident_active\","
+  echo "  \"operational_modes_tcas_ra_active\","
+  echo "  \"sil_supplement\","
+  echo "  \"single_antenna\","
+  echo "  \"utc_coupled\","
+  echo "  \"vv_src\","
+  echo "]"
+
+  ## Name override
+  echo "name_override = \"aircraft\""
+
+  ## Time key is the key containing the time that should be used to create the
+  ## metric.
+  echo "json_time_key = \"metadata_received_at\""
+
+  ## Time format is the time layout that should be used to interprete the
+  ## json_time_key.  The time must be `unix`, `unix_ms` or a time in the
+  ## "reference time".
+  echo "json_time_format =\"unix\""
+
+} > "$INPUT_JSON_CONFIG_FILE"

--- a/rootfs/etc/cont-init.d/04-telegraf
+++ b/rootfs/etc/cont-init.d/04-telegraf
@@ -24,24 +24,34 @@ if [[ -n "$INFLUXDBURL" ]]; then
 
   ##### TELEGRAF CONFIG - OUTPUT TO INFLUXDB #####
   {
-    echo "[[outputs.influxdb]]"
+    # if set, configure Telegraf to use InfluxDB v2.x
+    if [[ -n "${INFLUXDB_V2+x}"  ]]; then
+      echo "[[outputs.influxdb_v2]]"
+      echo "  urls = [\"${INFLUXDBURL}\"]"
+      echo "  token = \"${INFLUXDB_V2_TOKEN}\""
+      echo "  organization = \"${INFLUXDB_V2_ORG}\""
+      echo "  bucket = \"${INFLUXDB_V2_BUCKET}\""
+    else # else default to InfluxDB v1 output
+      echo "[[outputs.influxdb]]"
 
-    # Add InfluxDB URL
-    echo " urls = [\"${INFLUXDBURL}\"]"
+      # Add InfluxDB URL
+      echo " urls = [\"${INFLUXDBURL}\"]"
 
-    # Finish config
-    echo 'database = "dump978"'
-    echo 'skip_database_creation = false'
-    echo 'timeout = "5s"'
+      # Finish config
+      echo 'database = "dump978"'
+      echo 'skip_database_creation = false'
+      echo 'timeout = "5s"'
 
-    # If set, add InfluxDB username
-    if [[ -n "${INFLUXDBUSERNAME+x}" ]]; then
-      echo "username = \"${INFLUXDBUSERNAME}\""
-    fi
+      # If set, add InfluxDB username
+      if [[ -n "${INFLUXDBUSERNAME+x}" ]]; then
+        echo "username = \"${INFLUXDBUSERNAME}\""
+      fi
 
-    # If set, add InfluxDB password
-    if [[ -n "${INFLUXDBPASSWORD+x}" ]]; then
-      echo "password = \"${INFLUXDBPASSWORD}\""
+      # If set, add InfluxDB password
+      if [[ -n "${INFLUXDBPASSWORD+x}" ]]; then
+        echo "password = \"${INFLUXDBPASSWORD}\""
+      fi
+
     fi
 
   } > "$OUTPUT_INFLUXDB_CONFIG_FILE"

--- a/rootfs/etc/services.d/telegraf/run
+++ b/rootfs/etc/services.d/telegraf/run
@@ -3,7 +3,7 @@
 
 set -eo pipefail
 
-if [[ -n "$INFLUXDBURL" ]]; then
+if [[ -n "$INFLUXDBURL" ]] || [ -n "$ENABLE_PROMETHEUS" ]; then
 
   #shellcheck disable=SC2016
   telegraf \

--- a/rootfs/etc/services.d/telegraf_socat/run
+++ b/rootfs/etc/services.d/telegraf_socat/run
@@ -6,7 +6,7 @@
 
 set -eo pipefail
 
-if [[ -n "$INFLUXDBURL" ]]; then
+if [[ -n "$INFLUXDBURL" ]] || [ -n "$ENABLE_PROMETHEUS" ]; then
 
   SOCAT_BIN="$(which socat)"
   SOCAT_CMD=(-ls)


### PR DESCRIPTION
Adds prometheus and InfluxDB V2 outputs for telegraf, if enabled. Closes #26 