### PR TITLE
Increase HEALTHCHECK timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ EXPOSE 30978/tcp 30979/tcp 37981/tcp
 
 # Add healthcheck - very long start period due to relatively small number of UAT aircraft
 # May decrease start-period in future
-HEALTHCHECK --start-period=7200s --interval=600s CMD /scripts/healthcheck.sh
+HEALTHCHECK --timeout=60s --start-period=7200s --interval=600s CMD /scripts/healthcheck.sh
 
 # TODO
 #  - work out a way to test - maybe capture some output and parse it?


### PR DESCRIPTION
When running on an RPi3B I am noticing that once I accumulate 120 files in /run/uat2json/aircraft* it takes more than the default 30s to process all of the files with jq. This change increases the timeout to 60s.