### PR TITLE
bugfix: don't install librtlsdr0 via apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,6 @@ RUN set -x && \
     KEPT_PACKAGES+=(libncurses5) && \
     KEPT_PACKAGES+=(zlib1g) && \
     KEPT_PACKAGES+=(libzstd1) && \
-    KEPT_PACKAGES+=(librtlsdr0) && \
     KEPT_PACKAGES+=(libncurses6) && \
     # Install packages.
     apt-get update && \


### PR DESCRIPTION
the baseimage brings the osmocom rtl-sdr library that also supports rtl-sdr blog v4
librtlsdr0 from debian apt on the other hand does not support rtl-sdr blog v4