### PR TITLE
ci: fix DL3025

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,4 +82,4 @@ ENTRYPOINT [ "/init" ]
 EXPOSE 30978/tcp 30979/tcp 37981/tcp
 
 # Add healthcheck
-HEALTHCHECK --timeout=60s --start-period=7200s --interval=600s CMD /scripts/healthcheck.sh
+HEALTHCHECK --timeout=60s --start-period=7200s --interval=600s CMD ["/scripts/healthcheck.sh"]


### PR DESCRIPTION
## Problem

hadolint [#1209](https://github.com/hadolint/hadolint/pull/1209) extended `DL3025` to fire on `HEALTHCHECK ... CMD` as well as `CMD`/`ENTRYPOINT`, shipping in v2.15.0 (published 2026-07-30T13:39:01Z). `DL3025` itself is not new; only the `HEALTHCHECK` coverage is.

```console
$ hadolint --config <shared ruleset> Dockerfile     # 2.14.0, the flake.lock pin
rc=0

$ hadolint --config <shared ruleset> Dockerfile     # 2.15.1
Dockerfile:85 DL3025 warning: Use arguments JSON notation for CMD and ENTRYPOINT arguments
rc=1
```

`check_docker` is already `true` here, so this is a latent `Lint` failure on every PR the moment a `flake.lock` bump lands 2.15.x. There is no hadolint job in the deploy workflow, so the deploy path was never at risk.

## Changes

```diff
-HEALTHCHECK --timeout=60s --start-period=7200s --interval=600s CMD /scripts/healthcheck.sh
+HEALTHCHECK --timeout=60s --start-period=7200s --interval=600s CMD ["/scripts/healthcheck.sh"]
```

## Verification

The exec form drops the intervening `/bin/sh -c`, so the kernel must resolve the script's `#!/command/with-contenv bash` shebang itself — a symlink into the s6-overlay tree, not a normal interpreter path. Preconditions confirmed in the published image, then both forms run side by side under Docker's real healthcheck machinery — the **published image** (shell form) against a **local build of this branch** (exec form), with only the probe timing overridden:

```text
=== published / shell ===                    === rebuilt / exec ===
unhealthy                                    unhealthy
["CMD-SHELL","/scripts/healthcheck.sh"]      ["CMD","/scripts/healthcheck.sh"]
exit=1                                       exit=1
```

`unhealthy` is expected without UAT hardware; identical failure on both sides proves form-equivalence just as well as identical success would, and confirms exit codes still propagate in exec form.

The captured output matches on every line **except one** — the abnormal death count for the `dump978` service. That is per-invocation container state, not a form difference. Verified with a control: the same line varies across consecutive probes of a *single* container:

```text
probes mentioning a nonzero dump978 death count: 2
probes reporting zero:                           3
```

Both values occur within one container, so the shell-vs-exec difference on that line carries no signal.

Image config compared against the published image — only `Test[0]` differs:

```console
built    : {"Test":["CMD","/scripts/healthcheck.sh"],"Interval":600000000000,"Timeout":60000000000,"StartPeriod":7200000000000}
published: {"Test":["CMD-SHELL","/scripts/healthcheck.sh"],"Interval":600000000000,"Timeout":60000000000,"StartPeriod":7200000000000}
```

`Config.Entrypoint` is `["/init"]` on both, so s6 remains PID 1 and `docker stop` still reaches it for graceful shutdown.

Also checked:

- `nix develop -c pre-commit run --all-files`: green, all hooks Passed or Skipped
- `docker build --platform linux/amd64`: succeeds
- No hooks bypassed; no `--no-verify`
